### PR TITLE
Improve server packaging

### DIFF
--- a/src/JRPC-Common/JRPCBatchRequestsObject.class.st
+++ b/src/JRPC-Common/JRPCBatchRequestsObject.class.st
@@ -17,13 +17,12 @@ JRPCBatchRequestsObject class >> fromJRPCJSONObject: aJSONObject [
 	aJSONObject isArray
 		ifFalse: [ JRPCIncorrectJSON signal ].
 		
-	^ self new
+	^ self 
 		requests: (aJSONObject collect: [ :json | 
 			[ (JRPCMessageObject classToInstantiateForJSONObject: json forClient: false)
 				fromJRPCJSONObject: json
 			] on: JRPCIncorrectJSON do: [ :error |
-				error asJRPCResponse ] ]);
-		yourself
+				error asJRPCResponse ] ])
 ]
 
 { #category : #'instance creation' }

--- a/src/JRPC-Common/JRPCBatchRequestsObject.class.st
+++ b/src/JRPC-Common/JRPCBatchRequestsObject.class.st
@@ -38,14 +38,6 @@ JRPCBatchRequestsObject >> asJRPCJSON [
 	^ self requests collect: #asJRPCJSON
 ]
 
-{ #category : #'server handling' }
-JRPCBatchRequestsObject >> beHandledByServer: aJRPCServer [
-	^ JRPCBatchResponseObject new
-		responses: (self requests collect: [ :req |
-						req beHandledByServer: aJRPCServer ]);
-		yourself
-]
-
 { #category : #accessing }
 JRPCBatchRequestsObject >> requests [
 	^ requests

--- a/src/JRPC-Common/JRPCErrorResponseObject.class.st
+++ b/src/JRPC-Common/JRPCErrorResponseObject.class.st
@@ -35,12 +35,6 @@ JRPCErrorResponseObject >> asJRPCJSON [
 		yourself
 ]
 
-{ #category : #'server handling' }
-JRPCErrorResponseObject >> beHandledByServer: aJRPCServer [
-	"Returns self, this method is executed when a request inside a batch generated an error."
-	^ self
-]
-
 { #category : #accessing }
 JRPCErrorResponseObject >> error [
 	^ error

--- a/src/JRPC-Common/JRPCNotificationObject.class.st
+++ b/src/JRPC-Common/JRPCNotificationObject.class.st
@@ -32,22 +32,3 @@ JRPCNotificationObject >> asJRPCJSON [
 	dict removeKey: 'id'.
 	^ dict
 ]
-
-{ #category : #'server handling' }
-JRPCNotificationObject >> beHandledByServer: aJRPCServer [
-	| response |
-	response := super beHandledByServer: aJRPCServer.
-	"If the response is an error invalid request, it should be returned even if the request was a notification."
-	(response isError and: [ response isInvalidRequest ])
-		ifTrue: [ ^ response ].
-		
-	^ JRPCEmptyResponseObject new
-]
-
-{ #category : #'server handling' }
-JRPCNotificationObject >> convertErrorToResponse: jrpcError [
-	jrpcError isIncorrectJSON
-		ifTrue: [ ^ jrpcError asJRPCResponseWithId: self id ].
-	
-	^ JRPCEmptyResponseObject new
-]

--- a/src/JRPC-Common/JRPCRequestObject.class.st
+++ b/src/JRPC-Common/JRPCRequestObject.class.st
@@ -52,16 +52,6 @@ JRPCRequestObject >> asJRPCJSON [
 	^ dict
 ]
 
-{ #category : #'server handling' }
-JRPCRequestObject >> beHandledByServer: aJRPCServer [
-	^ aJRPCServer handleJRPCRequestObject: self
-]
-
-{ #category : #'server handling' }
-JRPCRequestObject >> convertErrorToResponse: jrpcError [
-	^ jrpcError asJRPCResponseWithId: self id
-]
-
 { #category : #accessing }
 JRPCRequestObject >> method [
 	^ method

--- a/src/JRPC-Server/BlockClosure.extension.st
+++ b/src/JRPC-Server/BlockClosure.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #BlockClosure }
 
-{ #category : #'*JRPC-Common' }
+{ #category : #'*JRPC-Server' }
 BlockClosure >> jrpcExecuteWithParameters: anArrayOrDictionary [
 	| arguments |
 	anArrayOrDictionary ifNil: [ 
@@ -15,12 +15,12 @@ BlockClosure >> jrpcExecuteWithParameters: anArrayOrDictionary [
 	^ self valueWithArguments: arguments
 ]
 
-{ #category : #'*JRPC-Common' }
+{ #category : #'*JRPC-Server' }
 BlockClosure >> jrpcParametersCount [
 	^ self argumentCount
 ]
 
-{ #category : #'*JRPC-Common' }
+{ #category : #'*JRPC-Server' }
 BlockClosure >> jrpcParametersNames [
 	^ self argumentNames asSet
 ]

--- a/src/JRPC-Server/JRPCBatchRequestsObject.extension.st
+++ b/src/JRPC-Server/JRPCBatchRequestsObject.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #JRPCBatchRequestsObject }
+
+{ #category : #'*JRPC-Server' }
+JRPCBatchRequestsObject >> beHandledByServer: aJRPCServer [
+	^ JRPCBatchResponseObject new
+		responses: (self requests collect: [ :req |
+						req beHandledByServer: aJRPCServer ]);
+		yourself
+]

--- a/src/JRPC-Server/JRPCErrorResponseObject.extension.st
+++ b/src/JRPC-Server/JRPCErrorResponseObject.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #JRPCErrorResponseObject }
+
+{ #category : #'*JRPC-Server' }
+JRPCErrorResponseObject >> beHandledByServer: aJRPCServer [
+	"Returns self, this method is executed when a request inside a batch generated an error."
+	^ self
+]

--- a/src/JRPC-Server/JRPCHTTPServer.class.st
+++ b/src/JRPC-Server/JRPCHTTPServer.class.st
@@ -17,6 +17,18 @@ JRPCHTTPServer class >> defaultPort [
 	^ 4000
 ]
 
+{ #category : #accessing }
+JRPCHTTPServer >> debugMode [
+
+	^ server debugMode
+]
+
+{ #category : #accessing }
+JRPCHTTPServer >> debugMode: boolean [
+
+	server debugMode: boolean
+]
+
 { #category : #defaults }
 JRPCHTTPServer >> defaultPort [
 	^ self class defaultPort
@@ -34,6 +46,12 @@ JRPCHTTPServer >> initialize [
 			( ZnDispatcherDelegate new
 				map: '/'
 				to: [ :request :response | response entity: ( ZnEntity json: ( self handleJSON: request contents ) ) ] )
+]
+
+{ #category : #accessing }
+JRPCHTTPServer >> port [
+
+	^ server port
 ]
 
 { #category : #accessing }

--- a/src/JRPC-Server/JRPCHTTPServer.class.st
+++ b/src/JRPC-Server/JRPCHTTPServer.class.st
@@ -37,11 +37,6 @@ JRPCHTTPServer >> initialize [
 ]
 
 { #category : #accessing }
-JRPCHTTPServer >> port [
-	^ server port
-]
-
-{ #category : #accessing }
 JRPCHTTPServer >> port: anInteger [
 	server port: anInteger
 ]

--- a/src/JRPC-Server/JRPCInvalidParameters.class.st
+++ b/src/JRPC-Server/JRPCInvalidParameters.class.st
@@ -4,7 +4,7 @@ I am an error raised when the parameters of the method called are invalid.
 Class {
 	#name : #JRPCInvalidParameters,
 	#superclass : #JRPCError,
-	#category : #'JRPC-Common-Errors'
+	#category : #'JRPC-Server'
 }
 
 { #category : #converting }

--- a/src/JRPC-Server/JRPCNonExistentHandler.class.st
+++ b/src/JRPC-Server/JRPCNonExistentHandler.class.st
@@ -4,23 +4,10 @@ I am an error raised when the handler required does not exist.
 Class {
 	#name : #JRPCNonExistentHandler,
 	#superclass : #JRPCError,
-	#instVars : [
-		'handlerName'
-	],
 	#category : #'JRPC-Server'
 }
 
 { #category : #converting }
 JRPCNonExistentHandler >> asJRPCResponseWithId: anInteger [
 	^ JRPCErrorResponseObject id: anInteger error: JRPCErrorObject methodNotFound
-]
-
-{ #category : #accessing }
-JRPCNonExistentHandler >> handlerName [
-	^ handlerName
-]
-
-{ #category : #accessing }
-JRPCNonExistentHandler >> handlerName: anObject [
-	handlerName := anObject
 ]

--- a/src/JRPC-Server/JRPCNonExistentHandler.class.st
+++ b/src/JRPC-Server/JRPCNonExistentHandler.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'handlerName'
 	],
-	#category : #'JRPC-Common-Errors'
+	#category : #'JRPC-Server'
 }
 
 { #category : #converting }

--- a/src/JRPC-Server/JRPCNotificationObject.extension.st
+++ b/src/JRPC-Server/JRPCNotificationObject.extension.st
@@ -1,0 +1,20 @@
+Extension { #name : #JRPCNotificationObject }
+
+{ #category : #'*JRPC-Server' }
+JRPCNotificationObject >> beHandledByServer: aJRPCServer [
+	| response |
+	response := super beHandledByServer: aJRPCServer.
+	"If the response is an error invalid request, it should be returned even if the request was a notification."
+	(response isError and: [ response isInvalidRequest ])
+		ifTrue: [ ^ response ].
+		
+	^ JRPCEmptyResponseObject new
+]
+
+{ #category : #'*JRPC-Server' }
+JRPCNotificationObject >> convertErrorToResponse: jrpcError [
+	jrpcError isIncorrectJSON
+		ifTrue: [ ^ jrpcError asJRPCResponseWithId: self id ].
+	
+	^ JRPCEmptyResponseObject new
+]

--- a/src/JRPC-Server/JRPCRequestObject.extension.st
+++ b/src/JRPC-Server/JRPCRequestObject.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #JRPCRequestObject }
+
+{ #category : #'*JRPC-Server' }
+JRPCRequestObject >> beHandledByServer: aJRPCServer [
+	^ aJRPCServer handleJRPCRequestObject: self
+]
+
+{ #category : #'*JRPC-Server' }
+JRPCRequestObject >> convertErrorToResponse: jrpcError [
+	^ jrpcError asJRPCResponseWithId: self id
+]

--- a/src/JRPC-Tests/JRPCHttpServerTest.class.st
+++ b/src/JRPC-Tests/JRPCHttpServerTest.class.st
@@ -19,6 +19,14 @@ JRPCHttpServerTest >> checkPortAvailability [
 ]
 
 { #category : #private }
+JRPCHttpServerTest >> newJRPCClient [
+
+	^ ( JRPCClient http: ( 'http://localhost' asUrl port: self port ) )
+		ifFail: [ self fail ];
+		yourself
+]
+
+{ #category : #private }
 JRPCHttpServerTest >> port [
 
 	^ 7777
@@ -43,6 +51,32 @@ JRPCHttpServerTest >> tearDown [
 ]
 
 { #category : #accessing }
+JRPCHttpServerTest >> testNotification [
+
+	| notificationCount |
+
+	notificationCount := 0.
+	server addHandlerNamed: 'mail_sent' block: [ notificationCount := notificationCount + 1 ].
+
+	self newJRPCClient notifyMethod: 'mail_sent'.
+
+	self assert: notificationCount equals: 1
+]
+
+{ #category : #accessing }
+JRPCHttpServerTest >> testNotificationWithInvalidMethod [
+
+	| notificationCount |
+
+	notificationCount := 0.
+	server addHandlerNamed: 'mail_sent' block: [ notificationCount := notificationCount + 1 ].
+
+	self newJRPCClient notifyMethod: 'invalid'.
+
+	self assert: notificationCount equals: 0
+]
+
+{ #category : #accessing }
 JRPCHttpServerTest >> testRequestOnInvalidEndpoint [
 
 	| httpClient failed |
@@ -62,13 +96,17 @@ JRPCHttpServerTest >> testRequestOnInvalidEndpoint [
 ]
 
 { #category : #accessing }
-JRPCHttpServerTest >> testValidRequest [
+JRPCHttpServerTest >> testRequestWithoutParameters [
 
-	| httpClient |
+	server addHandlerNamed: 'zero' block: [ 0 ].
+
+	self assert: ( self newJRPCClient callMethod: 'zero' withId: 3 ) result equals: 0
+]
+
+{ #category : #accessing }
+JRPCHttpServerTest >> testValidRequest [
 
 	server addHandlerNamed: 'sum' block: [ :a :b | a + b ].
 
-	httpClient := JRPCClient http: ( 'http://localhost' asUrl port: self port ).
-
-	self assert: ( httpClient callMethod: 'sum' arguments: #(1 3) withId: 1 ) result equals: 4
+	self assert: ( self newJRPCClient callMethod: 'sum' arguments: #(1 3) withId: 1 ) result equals: 4
 ]

--- a/src/JRPC-Tests/JRPCHttpServerTest.class.st
+++ b/src/JRPC-Tests/JRPCHttpServerTest.class.st
@@ -38,7 +38,12 @@ JRPCHttpServerTest >> setUp [
 	super setUp.
 	self checkPortAvailability.
 	server := JRPCServer http.
-	server port: self port.
+	server
+		port: self port;
+		debugMode: true.
+	self
+		assert: server port equals: self port;
+		assert: server debugMode.
 	server start
 ]
 


### PR DESCRIPTION
Moved methods used exclusively in the server code to JRPC-Server package, in order to not have this methods if you load only the Client group.