### PR TITLE
22-Add-possibility-for-a-handler-to-be-available-only-for-request-or-notification

### DIFF
--- a/src/BaselineOfJRPC/BaselineOfJRPC.class.st
+++ b/src/BaselineOfJRPC/BaselineOfJRPC.class.st
@@ -41,7 +41,7 @@ BaselineOfJRPC >> setUpPackages: spec [
 
 	spec
 		group: 'Deployment'
-		with: #('Server-Deployment' 'HTTP-Transport' 'TCP-Transport' 'Client-Deployment').
+		with: #('Server-Deployment' 'HTTP-Transport' 'TCP-Transport' 'Client-Deployment' 'JRPC-Server-Deprecated').
 
 	spec
 		package: 'JRPC-Tests' with: [ spec requires: 'Deployment' ];
@@ -67,5 +67,8 @@ BaselineOfJRPC >> setUpServerDeploymentPackages: spec [
 
 	spec
 		package: 'JRPC-Server-TCP' with: [ spec requires: 'JRPC-Server-Core' ];
-		group: 'TCP-Transport' with: 'JRPC-Server-TCP'
+		group: 'TCP-Transport' with: 'JRPC-Server-TCP'.
+		
+	spec
+		package: 'JRPC-Server-Deprecated' with: [ spec requires: 'JRPC-Server-Core' ]
 ]

--- a/src/JRPC-Common/JRPCMessageObject.class.st
+++ b/src/JRPC-Common/JRPCMessageObject.class.st
@@ -84,6 +84,16 @@ JRPCMessageObject >> initialize [
 	jsonrpc := JSONRPC
 ]
 
+{ #category : #testing }
+JRPCMessageObject >> isNotification [
+	^ false
+]
+
+{ #category : #testing }
+JRPCMessageObject >> isRequest [
+	^ false
+]
+
 { #category : #accessing }
 JRPCMessageObject >> jsonrpc [
 	^ jsonrpc

--- a/src/JRPC-Common/JRPCNotificationObject.class.st
+++ b/src/JRPC-Common/JRPCNotificationObject.class.st
@@ -25,10 +25,28 @@ JRPCNotificationObject class >> fromJRPCJSONObject: aDictionary [
 		yourself
 ]
 
+{ #category : #accessing }
+JRPCNotificationObject class >> method: aString [
+	^ self new
+		method: aString;
+		params: nil;
+		yourself
+]
+
 { #category : #converting }
 JRPCNotificationObject >> asJRPCJSON [
 	| dict |
 	dict := super asJRPCJSON.
 	dict removeKey: 'id'.
 	^ dict
+]
+
+{ #category : #testing }
+JRPCNotificationObject >> isNotification [
+	^ true
+]
+
+{ #category : #testing }
+JRPCNotificationObject >> isRequest [
+	^ false
 ]

--- a/src/JRPC-Common/JRPCRequestObject.class.st
+++ b/src/JRPC-Common/JRPCRequestObject.class.st
@@ -52,6 +52,11 @@ JRPCRequestObject >> asJRPCJSON [
 	^ dict
 ]
 
+{ #category : #testing }
+JRPCRequestObject >> isRequest [
+	^ true
+]
+
 { #category : #accessing }
 JRPCRequestObject >> method [
 	^ method

--- a/src/JRPC-Server-Core/JRPCAbstractHandler.class.st
+++ b/src/JRPC-Server-Core/JRPCAbstractHandler.class.st
@@ -11,7 +11,9 @@ Class {
 	#name : #JRPCAbstractHandler,
 	#superclass : #Object,
 	#instVars : [
-		'methodName'
+		'methodName',
+		'isForNotification',
+		'isForRequest'
 	],
 	#category : #'JRPC-Server-Core'
 }
@@ -20,6 +22,12 @@ Class {
 JRPCAbstractHandler class >> defaultMethodName [
 	"Returns the method name that will be set to the handler instance by default."
 	^ self subclassResponsibility
+]
+
+{ #category : #testing }
+JRPCAbstractHandler >> canHandle: aRequestOrNotification [
+	^ (self isForRequest and: [ aRequestOrNotification isRequest ])
+		or: [ self isForNotification and: [ aRequestOrNotification isNotification ] ]
 ]
 
 { #category : #'parameters-checking' }
@@ -45,6 +53,33 @@ JRPCAbstractHandler >> defaultMethodName [
 { #category : #evaluation }
 JRPCAbstractHandler >> executeWithArguments: anArrayOrDictionary [
 	^ self subclassResponsibility
+]
+
+{ #category : #initialization }
+JRPCAbstractHandler >> initialize [
+	super initialize.
+	self isForRequest: true.
+	self isForNotification: true
+]
+
+{ #category : #accessing }
+JRPCAbstractHandler >> isForNotification [
+	^ isForNotification
+]
+
+{ #category : #accessing }
+JRPCAbstractHandler >> isForNotification: anObject [
+	isForNotification := anObject
+]
+
+{ #category : #accessing }
+JRPCAbstractHandler >> isForRequest [
+	^ isForRequest
+]
+
+{ #category : #accessing }
+JRPCAbstractHandler >> isForRequest: anObject [
+	isForRequest := anObject
 ]
 
 { #category : #accessing }

--- a/src/JRPC-Server-Core/JRPCMessageProcessor.class.st
+++ b/src/JRPC-Server-Core/JRPCMessageProcessor.class.st
@@ -93,7 +93,7 @@ JRPCMessageProcessor >> handleJRPCRequestObject: aJRPCRequestObject [
 
 	^ [ | handler result |
 
-	handler := self handlerForName: aJRPCRequestObject method.
+	handler := self handlerFor: aJRPCRequestObject.
 	handler checkParametersForRequest: aJRPCRequestObject.
 	result := handler executeWithArguments: aJRPCRequestObject params.
 	JRPCSuccessResponseObject id: aJRPCRequestObject id result: result
@@ -123,12 +123,17 @@ JRPCMessageProcessor >> handledMethodsCount [
 ]
 
 { #category : #accessing }
-JRPCMessageProcessor >> handlerForName: methodName [
-
-	methodName isString
+JRPCMessageProcessor >> handlerFor: requestOrNotification [
+	| candidateHandler |
+	requestOrNotification method isString
 		ifFalse: [ JRPCIncorrectJSON signal ].
 
-	^ handlersByName at: methodName ifAbsent: [ JRPCNonExistentHandler signal: methodName ]
+	candidateHandler := handlersByName at: requestOrNotification method ifAbsent: [ JRPCNonExistentHandler signal: requestOrNotification method ].
+	
+	(candidateHandler canHandle: requestOrNotification)
+		ifFalse: [ JRPCNonExistentHandler signal: requestOrNotification method ].
+	
+	^ candidateHandler
 ]
 
 { #category : #initialization }

--- a/src/JRPC-Server-Deprecated/JRPCMessageProcessor.extension.st
+++ b/src/JRPC-Server-Deprecated/JRPCMessageProcessor.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #JRPCMessageProcessor }
+
+{ #category : #'*JRPC-Server-Deprecated' }
+JRPCMessageProcessor >> handlerForName: methodName [
+	
+	self deprecated: 'This method has been deprecated in favor of #handlerFor: that takes a request or a notificaiton as argument.
+Thus, this method is not used internally by the message processor anymore.
+This change was done to allow one to define handler that only deal with request or only with notification (it is still possible to deal with both and this is the default btw).
+This method will be removed in next major version.'.
+	methodName isString
+		ifFalse: [ JRPCIncorrectJSON signal ].
+
+	^ handlersByName at: methodName ifAbsent: [ JRPCNonExistentHandler signal: methodName ]
+]

--- a/src/JRPC-Server-Deprecated/JRPCMessageProcessorTest.extension.st
+++ b/src/JRPC-Server-Deprecated/JRPCMessageProcessorTest.extension.st
@@ -1,0 +1,20 @@
+Extension { #name : #JRPCMessageProcessorTest }
+
+{ #category : #'*JRPC-Server-Deprecated' }
+JRPCMessageProcessorTest >> testHandlerForName [
+
+	| messageProcessor block handler |
+
+	messageProcessor := JRPCMessageProcessor new.
+
+	self should: [ messageProcessor handlerForName: 'powerOf2' ] raise: JRPCNonExistentHandler.
+
+	block := [ :anInteger | anInteger ** 2 ].
+
+	messageProcessor addHandlerNamed: 'powerOf2' block: block.
+	handler := messageProcessor handlerForName: 'powerOf2'.
+
+	self
+		assert: handler methodName equals: 'powerOf2';
+		assert: handler block equals: block
+]

--- a/src/JRPC-Server-Deprecated/package.st
+++ b/src/JRPC-Server-Deprecated/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'JRPC-Server-Deprecated' }

--- a/src/JRPC-Tests/JRPCMessageProcessorTest.class.st
+++ b/src/JRPC-Tests/JRPCMessageProcessorTest.class.st
@@ -7,21 +7,66 @@ Class {
 	#category : #'JRPC-Tests'
 }
 
-{ #category : #tests }
-JRPCMessageProcessorTest >> testHandlerForName [
-
+{ #category : #test }
+JRPCMessageProcessorTest >> testHandlerFor [
 	| messageProcessor block handler |
 
 	messageProcessor := JRPCMessageProcessor new.
 
-	self should: [ messageProcessor handlerForName: 'powerOf2' ] raise: JRPCNonExistentHandler.
+	self should: [ messageProcessor handlerFor: (JRPCRequestObject id: 1 method: 'powerOf2') ] raise: JRPCNonExistentHandler.
 
 	block := [ :anInteger | anInteger ** 2 ].
 
 	messageProcessor addHandlerNamed: 'powerOf2' block: block.
-	handler := messageProcessor handlerForName: 'powerOf2'.
+	handler := messageProcessor handlerFor: (JRPCRequestObject id: 1 method: 'powerOf2').
 
 	self
 		assert: handler methodName equals: 'powerOf2';
 		assert: handler block equals: block
+]
+
+{ #category : #test }
+JRPCMessageProcessorTest >> testHandlerForHandlerThatDealWithNotificationOnly [
+	| messageProcessor block handler |
+
+	messageProcessor := JRPCMessageProcessor new.
+
+	block := [ :anInteger | anInteger ** 2 ].
+
+	messageProcessor addHandler: (JRPCBlockHandler new
+											methodName: 'powerOf2';
+											block: block;
+											isForRequest: false;
+											yourself).
+	
+	handler := messageProcessor handlerFor: (JRPCNotificationObject method: 'powerOf2').
+
+	self
+		assert: handler methodName equals: 'powerOf2';
+		assert: handler block equals: block.
+		
+	self should: [ messageProcessor handlerFor: (JRPCRequestObject id: 1 method: 'powerOf2') ] raise: JRPCNonExistentHandler.
+]
+
+{ #category : #test }
+JRPCMessageProcessorTest >> testHandlerForHandlerThatDealWithRequestOnly [
+	| messageProcessor block handler |
+
+	messageProcessor := JRPCMessageProcessor new.
+
+	block := [ :anInteger | anInteger ** 2 ].
+
+	messageProcessor addHandler: (JRPCBlockHandler new
+											methodName: 'powerOf2';
+											block: block;
+											isForNotification: false;
+											yourself).
+	
+	handler := messageProcessor handlerFor: (JRPCRequestObject id: 1 method: 'powerOf2').
+
+	self
+		assert: handler methodName equals: 'powerOf2';
+		assert: handler block equals: block.
+		
+	self should: [ messageProcessor handlerFor: (JRPCNotificationObject method: 'powerOf2') ] raise: JRPCNonExistentHandler.
 ]


### PR DESCRIPTION
Extended server implementation to allow one to define handler that only deal with request or notification.It is still possible to have handler dealing with both (this is the default behavior).Added tests for this new feature.Deprecated #handlerForName: and the related test because in the future I plan to let user create 2 handlers with same method name but one that react to notification and the other to request.Thus, #handlerForName: will not make sense anymore.But this will be for the next major release as it will be breaking change.Added server deprecated package and adapted baseline.Fixes #22