### PR TITLE
26-Propose-a-debug-mode-for-the-JRPCMessageProcessor

### DIFF
--- a/src/JRPC-Server-Core/JRPCMessageProcessor.class.st
+++ b/src/JRPC-Server-Core/JRPCMessageProcessor.class.st
@@ -11,7 +11,8 @@ Class {
 	#traits : 'JRPCParser',
 	#classTraits : 'JRPCParser classTrait',
 	#instVars : [
-		'handlersByName'
+		'handlersByName',
+		'debugMode'
 	],
 	#category : #'JRPC-Server-Core'
 }
@@ -59,6 +60,16 @@ JRPCMessageProcessor >> canHandleMethodNamed: methodName [
 	^ handlersByName includesKey: methodName
 ]
 
+{ #category : #accessing }
+JRPCMessageProcessor >> debugMode [
+	^ debugMode
+]
+
+{ #category : #accessing }
+JRPCMessageProcessor >> debugMode: anObject [
+	debugMode := anObject
+]
+
 { #category : #'handling - jrpc' }
 JRPCMessageProcessor >> handleJRPCNotificationObject: aJRPCNotificationObject [
 	"A Notification is a Request object without an 'id' member.
@@ -99,19 +110,26 @@ JRPCMessageProcessor >> handleJRPCRequestObject: aJRPCRequestObject [
 	JRPCSuccessResponseObject id: aJRPCRequestObject id result: result
 	]
 		on: Error
-		do: [ :jrpcError | jrpcError return: ( aJRPCRequestObject convertErrorToResponse: jrpcError ) ]
+		do: [ :jrpcError | 
+			self debugMode
+				ifTrue: [ jrpcError pass ]
+				ifFalse: [ jrpcError return: ( aJRPCRequestObject convertErrorToResponse: jrpcError ) ] ]
 ]
 
 { #category : #'handling - json' }
 JRPCMessageProcessor >> handleJSON: aJSONString [
-
-	"Gets aJSONString as input and returns a JSON string."
+	"Gets aJSONString being a request or notification serialized in JSON format as input
+	 and returns a JSON string being the answer serialized in JSON format.
+	"
 
 	| jrpcResponse |
 
 	jrpcResponse := [ ( self parseSupposedJRPCMessageObjectFromString: aJSONString ) beHandledBy: self ]
 		on: Error
-		do: [ :error | error return: error asJRPCResponse ].
+		do: [ :error | 
+			self debugMode
+				ifTrue: [ error pass ]
+				ifFalse: [ error return: error asJRPCResponse ] ].
 
 	^ jrpcResponse beConvertedBy: self
 ]
@@ -140,7 +158,8 @@ JRPCMessageProcessor >> handlerFor: requestOrNotification [
 JRPCMessageProcessor >> initialize [
 
 	super initialize.
-	handlersByName := Dictionary new
+	handlersByName := Dictionary new.
+	self debugMode: false
 ]
 
 { #category : #testing }

--- a/src/JRPC-Server-Core/JRPCServer.class.st
+++ b/src/JRPC-Server-Core/JRPCServer.class.st
@@ -31,6 +31,16 @@ JRPCServer >> addHandlersFromPragmasIn: anObject [
 	messageProcessor addHandlersFromPragmasIn: anObject
 ]
 
+{ #category : #accessing }
+JRPCServer >> debugMode [
+	^ self messageProcessor debugMode
+]
+
+{ #category : #accessing }
+JRPCServer >> debugMode: aBoolean [
+	^ self messageProcessor debugMode: aBoolean
+]
+
 { #category : #'handling - jrpc' }
 JRPCServer >> handleJRPCRequestObject: aJRPCRequestObject [
 

--- a/src/JRPC-Tests/JRPCMessageProcessorTest.class.st
+++ b/src/JRPC-Tests/JRPCMessageProcessorTest.class.st
@@ -8,6 +8,35 @@ Class {
 }
 
 { #category : #test }
+JRPCMessageProcessorTest >> testDebugMode [
+	| messageProcessor |
+	messageProcessor := JRPCMessageProcessor new.
+	
+	self deny: messageProcessor debugMode.
+	
+	messageProcessor debugMode: true.
+	
+	self assert: messageProcessor debugMode.
+]
+
+{ #category : #test }
+JRPCMessageProcessorTest >> testDebugModeDoNotCatchError [
+	| messageProcessor |
+	messageProcessor := JRPCMessageProcessor new.
+	messageProcessor debugMode: true.
+	
+	messageProcessor addHandlerNamed: 'error' block: [ Error signal ].
+	
+	self should: [ (JRPCRequestObject id: 1 method: 'error') beHandledBy: messageProcessor ]
+		raise: Error.
+		
+	messageProcessor debugMode: false.
+	
+	self shouldnt: [ (JRPCRequestObject id: 1 method: 'error') beHandledBy: messageProcessor ]
+		raise: Error.
+]
+
+{ #category : #test }
 JRPCMessageProcessorTest >> testHandlerFor [
 	| messageProcessor block handler |
 

--- a/src/JRPC-Tests/JRPCServerTest.class.st
+++ b/src/JRPC-Tests/JRPCServerTest.class.st
@@ -86,6 +86,17 @@ JRPCServerTest >> testAddHandlersFromPragmasIn [
 		assert: ( self messageProcessor canHandleMethodNamed: 'stack_push' )
 ]
 
+{ #category : #test }
+JRPCServerTest >> testDebugMode [
+	self deny: server debugMode.
+	self deny: server messageProcessor debugMode.
+	
+	server debugMode: true.
+	
+	self assert: server debugMode.
+	self assert: server messageProcessor debugMode
+]
+
 { #category : #tests }
 JRPCServerTest >> testHandleJRPCRequestObject [
 	| requestForNonExistentHandler response |


### PR DESCRIPTION
Added a debug mode to the message processor so it is possible to let it open debugger when an error occurs.
Added tests for this feature.Fix #26