### PR TITLE
39-Enhance-JRPC-client-to-allow-tunnelling-in-other-protocol

### DIFF
--- a/src/JRPC-Client/JRPCClient.class.st
+++ b/src/JRPC-Client/JRPCClient.class.st
@@ -82,11 +82,21 @@ JRPCClient >> sendNotification: aJRPCNotificationObject [
 
 { #category : #'private - sending' }
 JRPCClient >> sendRequest: aJRPCRequestObject [
-	"To be implemented by concrete subclasses.
-	 Sends aJRPCRequestObject to the server to which the client is connected.
+	"Sends aJRPCRequestObject to the server to which the client is connected.
 	 Returns a JRPCSuccessResponseObject if everything goes well.
 	 Returns a JRPCErrorResponse if something went wrong.
 	"
 	
+	| rawResult |
+	rawResult := self sendRequestContent: ( self convertJRPCJsonableObjectToJSON: aJRPCRequestObject asJRPCJSON ).
+	^ self parseSupposedJRPCMessageObjectFromString: rawResult
+]
+
+{ #category : #'private - sending' }
+JRPCClient >> sendRequestContent: aString [
+	"To be implemented by concrete subclasses.
+	 Sends aString (containing an encoded JRPC object) to the server to which the client is connected.
+	 Returns the String returned by the server.
+	"
 	^ self subclassResponsibility
 ]

--- a/src/JRPC-Client/JRPCHTTPClient.class.st
+++ b/src/JRPC-Client/JRPCHTTPClient.class.st
@@ -36,15 +36,15 @@ JRPCHTTPClient >> initialize [
 ]
 
 { #category : #'private - sending' }
-JRPCHTTPClient >> sendRequest: aJRPCRequestObject [
+JRPCHTTPClient >> sendRequestContent: aString [
 
 	| result |
 
 	result := httpClient
-		contents: ( self convertJRPCJsonableObjectToJSON: aJRPCRequestObject asJRPCJSON );
+		contents: aString;
 		post.
 
-	^ self parseSupposedJRPCMessageObjectFromString: ( result ifNil: [ '' ] ifNotNil: #contents )
+	^ result ifNil: [ '' ] ifNotNil: #contents
 ]
 
 { #category : #accessing }

--- a/src/JRPC-Client/JRPCStreamClient.class.st
+++ b/src/JRPC-Client/JRPCStreamClient.class.st
@@ -56,8 +56,8 @@ JRPCStreamClient >> requestsSeparator: anObject [
 ]
 
 { #category : #'private - sending' }
-JRPCStreamClient >> sendRequest: aJRPCRequestObject [
-	self convertJRPCJsonableObjectToJSON: aJRPCRequestObject asJRPCJSON on: self writeStream.
+JRPCStreamClient >> sendRequestContent: aString [
+	self convertJRPCJsonableObjectToJSON: aString on: self writeStream.
 	self writeStream
 		nextPutAll: self requestsSeparator.
 		
@@ -65,7 +65,7 @@ JRPCStreamClient >> sendRequest: aJRPCRequestObject [
 	
 	"Needs to parse from a String here because it is possible that the stream
 	 provided can not do look ahead (the JSON parser needs that)."
-	^ self parseSupposedJRPCMessageObjectFromString: self readStream upToEnd
+	^ self readStream upToEnd
 ]
 
 { #category : #accessing }

--- a/src/JRPC-Client/JRPCTCPClient.class.st
+++ b/src/JRPC-Client/JRPCTCPClient.class.st
@@ -44,15 +44,14 @@ JRPCTCPClient >> port: anObject [
 ]
 
 { #category : #'private - sending' }
-JRPCTCPClient >> sendRequest: aJRPCRequestObject [
+JRPCTCPClient >> sendRequestContent: aString [
 	| socket result |
 	socket := Socket newTCP.
 	socket
 		connectTo: self address
 		port: self port.
-	socket
-		sendData: (self convertJRPCJsonableObjectToJSON: aJRPCRequestObject asJRPCJSON).
+	socket sendData: aString.
 	result := socket receiveData.
 	socket closeAndDestroy.
-	^ self parseSupposedJRPCMessageObjectFromString: result
+	^ result
 ]


### PR DESCRIPTION
Created #sendRequestContent: that has the responsibility to send the string over the network,
Implemented this method in subclasses.
Removed #sendRequest: from subclasses.
Rewrote #sendRequest: in JRPCClient.Fixes #39