### PR TITLE
Improve JRPCHTTPClient to set the content type when sending requests.

### DIFF
--- a/src/JRPC-Client/JRPCHTTPClient.class.st
+++ b/src/JRPC-Client/JRPCHTTPClient.class.st
@@ -42,6 +42,7 @@ JRPCHTTPClient >> sendRequest: aJRPCRequestObject [
 
 	result := httpClient
 		contents: ( self convertJRPCJsonableObjectToJSON: aJRPCRequestObject asJRPCJSON );
+		contentType: ZnMimeType applicationJson;
 		post.
 
 	^ self parseSupposedJRPCMessageObjectFromString: ( result ifNil: [ '' ] ifNotNil: #contents )


### PR DESCRIPTION
Some implementations requires `application/json` as the content type when using HTTP transport. See also https://www.simple-is-better.org/json-rpc/transport_http.html

This PR improves interoperability.